### PR TITLE
Bl 4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ##### Rockylinux9 OpenJDK 17
 
-* [4.6.0, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.0/Dockerfile)
+* [4.6.1, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.1/)
+* [4.6.0](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.0/Dockerfile)
 * [4.5.4](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.5.4/Dockerfile)
 * [4.5.3](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.5.3/Dockerfile)
 
@@ -33,7 +34,7 @@
 <a name="supported-architectures"></a>
 # Supported Architectures [↑](#top)
 
-Docker images for BridgeLink 4.6.0 and later versions support both `linux/amd64` and `linux/arm64` architectures. 
+Docker images for BridgeLink 4.6.1 and later versions support both `linux/amd64` and `linux/arm64` architectures. 
 ```
 docker pull --platform linux/arm64 innovarhealthcare/bridgelink:latest
 ```
@@ -89,13 +90,13 @@ docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink
 To run a specific version of Connect, specify a tag at the end:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:4.6.0
+docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:4.6.1
 ```
 
 To run using a specific architecture, specify it using the `--platform` argument:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:4.6.0
+docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:4.6.1
 ```
 
 Look at the [Environment Variables](#environment-variables) section for more available configuration options.
@@ -117,7 +118,7 @@ Here's an example `stack.yml` file you can use:
 version: "3.1"
 services:
   mc:
-    image: innovarhealthcare/bridgelink:4.6.0
+    image: innovarhealthcare/bridgelink:4.6.1
     platform: linux/amd64
     environment:
         - MP_DATABASE=postgres

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # URL of the .tar.gz file
-URL="https://innovar-oss-mirth-mirror.s3.us-east-2.amazonaws.com/mirth-arch/BridgeLink-4.6.0/BridgeLink_unix_4_6_0.tar.gz"
+URL="https://innovar-oss-mirth-mirror.s3.us-east-2.amazonaws.com/mirth-arch/BridgeLink-4.6.1/BridgeLink_unix_4_6_1.tar.gz"
 
 # Destination folder path
 DESTINATION_FOLDER="/opt"
 
 # Name of the downloaded file
-FILE_NAME="BridgeLink_unix_4_6_0.tar.gz"
+FILE_NAME="BridgeLink_unix_4_6_1.tar.gz"
 
 # Log file for debugging
 LOG_FILE="/opt/scripts/download_and_extract.log"


### PR DESCRIPTION
This pull request updates documentation and installation scripts to reference BridgeLink version 4.6.1 instead of 4.6.0. The changes ensure users are directed to the latest version for downloads, Docker images, and usage instructions.

Version update references:

* Updated all Docker image references in `README.md` to use `4.6.1` instead of `4.6.0`, including example commands and stack configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R99) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R121)
* Changed architecture support documentation to indicate that multi-architecture images are available starting with BridgeLink 4.6.1.

Installation script update:

* Modified the `scripts/install.sh` script to download and extract BridgeLink version 4.6.1, updating both the URL and the file name variables.