### PR TITLE
BridgeLink 26.3.0 Docker build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Install AWS CLI (multi-arch: detects amd64/arm64)
 RUN ARCH=$(uname -m) && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
+    curl --retry 5 --retry-delay 5 "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     /aws/install && \
     rm -rf aws*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,19 @@ RUN yum -y install java-17-openjdk java-17-openjdk-devel
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 ENV PATH=$JAVA_HOME/bin:$PATH
 
-# Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+# Install AWS CLI (multi-arch: detects amd64/arm64)
+RUN ARCH=$(uname -m) && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     /aws/install && \
     rm -rf aws*
 
 # Create the bridgelink user with UID 1000
 RUN useradd -u 1000 bridgelink
+
+# Binary download URL — passed at build time (s3:// for internal, https:// for public release)
+ARG BINARY_URL
+ENV BINARY_URL=${BINARY_URL}
 
 # Copy in the necessary scripts and ensure they are executable
 COPY scripts/install.sh /opt/scripts/install.sh
@@ -35,7 +40,9 @@ RUN chmod +x /opt/scripts/install.sh /opt/scripts/entrypoint.sh
 RUN ls -l /opt/scripts/
 
 # Run the installation script which sets up your application under /opt/bridgelink
-RUN /opt/scripts/install.sh
+# AWS credentials are injected via build secret (never baked into the image)
+RUN --mount=type=secret,id=aws_credentials,target=/root/.aws/credentials \
+    /opt/scripts/install.sh
 
 # Create required directories for persistent data and set ownership
 RUN mkdir -p /opt/bridgelink/appdata && chown bridgelink:bridgelink /opt/bridgelink/appdata && \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ##### Rockylinux9 OpenJDK 17
 
-* [4.6.1, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.1/)
+* [26.3.0, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_26.3.0/)
+* [4.6.1](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.1/Dockerfile)
 * [4.6.0](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.0/Dockerfile)
 * [4.5.4](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.5.4/Dockerfile)
 * [4.5.3](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.5.3/Dockerfile)
@@ -34,7 +35,7 @@
 <a name="supported-architectures"></a>
 # Supported Architectures [↑](#top)
 
-Docker images for BridgeLink 4.6.1 and later versions support both `linux/amd64` and `linux/arm64` architectures. 
+Docker images for BridgeLink 26.3.0 and later versions support both `linux/amd64` and `linux/arm64` architectures.
 ```
 docker pull --platform linux/arm64 innovarhealthcare/bridgelink:latest
 ```
@@ -90,13 +91,13 @@ docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink
 To run a specific version of Connect, specify a tag at the end:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:4.6.1
+docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:26.3.0
 ```
 
 To run using a specific architecture, specify it using the `--platform` argument:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:4.6.1
+docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:26.3.0
 ```
 
 Look at the [Environment Variables](#environment-variables) section for more available configuration options.
@@ -118,7 +119,7 @@ Here's an example `stack.yml` file you can use:
 version: "3.1"
 services:
   mc:
-    image: innovarhealthcare/bridgelink:4.6.1
+    image: innovarhealthcare/bridgelink:26.3.0
     platform: linux/amd64
     environment:
         - MP_DATABASE=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - "8443:8443"
     volumes:
       - ./appdata:/opt/bridgelink/appdata
-    # secrets:
-    #   - blserver_vmoptions
     environment:
       MP_DATABASE: postgres
       MP_DATABASE_URL: jdbc:postgresql://postgres:5432/bridgelinkdb
@@ -23,7 +21,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:14-alpine
+    image: postgres:16-alpine
     ports:
       - 5432:5432
     environment:
@@ -31,6 +29,3 @@ services:
       POSTGRES_USER: bridgelinktest
       POSTGRES_DB: bridgelinkdb
 
-# secrets:
-#   blserver_vmoptions:
-#     file: appdata/custom_blserver.vmoptions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bl:
-    image: innovarhealthcare/bridgelink:4.5.4
+    image: innovarhealthcare/bridgelink:26.3.0-qa
     stdin_open: true
     tty: true
     user: 1000:1000
@@ -8,8 +8,8 @@ services:
       - "8443:8443"
     volumes:
       - ./appdata:/opt/bridgelink/appdata
-    secrets:
-      - blserver_vmoptions
+    # secrets:
+    #   - blserver_vmoptions
     environment:
       MP_DATABASE: postgres
       MP_DATABASE_URL: jdbc:postgresql://postgres:5432/bridgelinkdb
@@ -31,6 +31,6 @@ services:
       POSTGRES_USER: bridgelinktest
       POSTGRES_DB: bridgelinkdb
 
-secrets:
-  blserver_vmoptions:
-    file: appdata/custom_blserver.vmoptions
+# secrets:
+#   blserver_vmoptions:
+#     file: appdata/custom_blserver.vmoptions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,17 +20,24 @@ LOG_FILE="/opt/scripts/download_and_extract.log"
 echo "Starting download and extract script" | tee -a "$LOG_FILE"
 echo "Destination: $DESTINATION_FOLDER" | tee -a "$LOG_FILE"
 
-# Download the binary
+# Download the binary with retry
 echo "Downloading binary..." | tee -a "$LOG_FILE"
-if [[ "$BINARY_URL" == s3://* ]]; then
-  aws s3 cp "$BINARY_URL" "$FILE_NAME" 2>&1 | tee -a "$LOG_FILE"
-else
-  curl -L --max-time 10000 -o "$FILE_NAME" "$BINARY_URL" 2>&1 | tee -a "$LOG_FILE"
-fi
-if [ $? -ne 0 ]; then
-  echo "Download failed" | tee -a "$LOG_FILE"
-  exit 1
-fi
+MAX_RETRIES=5
+RETRY_DELAY=10
+for i in $(seq 1 $MAX_RETRIES); do
+  if [[ "$BINARY_URL" == s3://* ]]; then
+    aws s3 cp "$BINARY_URL" "$FILE_NAME" 2>&1 | tee -a "$LOG_FILE"
+  else
+    curl -L --max-time 10000 -o "$FILE_NAME" "$BINARY_URL" 2>&1 | tee -a "$LOG_FILE"
+  fi
+  [ $? -eq 0 ] && break
+  echo "Download attempt $i failed, retrying in ${RETRY_DELAY}s..." | tee -a "$LOG_FILE"
+  sleep $RETRY_DELAY
+  if [ $i -eq $MAX_RETRIES ]; then
+    echo "Download failed after $MAX_RETRIES attempts" | tee -a "$LOG_FILE"
+    exit 1
+  fi
+done
 
 # Create the destination folder if it doesn't exist
 echo "Creating destination folder..." | tee -a "$LOG_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,27 +1,34 @@
 #!/bin/bash
 
-# URL of the .tar.gz file
-URL="https://innovar-oss-mirth-mirror.s3.us-east-2.amazonaws.com/mirth-arch/BridgeLink-4.6.1/BridgeLink_unix_4_6_1.tar.gz"
+# BINARY_URL must be provided at build time via --build-arg
+# Supports both s3:// (uses aws s3 cp) and https:// (uses curl)
+if [ -z "$BINARY_URL" ]; then
+  echo "ERROR: BINARY_URL build arg is not set" | tee -a "$LOG_FILE"
+  exit 1
+fi
 
 # Destination folder path
 DESTINATION_FOLDER="/opt"
 
 # Name of the downloaded file
-FILE_NAME="BridgeLink_unix_4_6_1.tar.gz"
+FILE_NAME="BridgeLink_unix_26_3_0.tar.gz"
 
 # Log file for debugging
 LOG_FILE="/opt/scripts/download_and_extract.log"
 
 # Start logging
 echo "Starting download and extract script" | tee -a "$LOG_FILE"
-echo "URL: $URL" | tee -a "$LOG_FILE"
 echo "Destination: $DESTINATION_FOLDER" | tee -a "$LOG_FILE"
 
-# Download the file with a timeout
-echo "Downloading file..." | tee -a "$LOG_FILE"
-curl -L --max-time 10000 -o "$FILE_NAME" "$URL" 2>&1 | tee -a "$LOG_FILE"
+# Download the binary
+echo "Downloading binary..." | tee -a "$LOG_FILE"
+if [[ "$BINARY_URL" == s3://* ]]; then
+  aws s3 cp "$BINARY_URL" "$FILE_NAME" 2>&1 | tee -a "$LOG_FILE"
+else
+  curl -L --max-time 10000 -o "$FILE_NAME" "$BINARY_URL" 2>&1 | tee -a "$LOG_FILE"
+fi
 if [ $? -ne 0 ]; then
-  echo "Download failed or timed out" | tee -a "$LOG_FILE"
+  echo "Download failed" | tee -a "$LOG_FILE"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Update `install.sh` to use `$BINARY_URL` build arg — supports `s3://` (aws s3 cp) and `https://` (curl); no internal paths hardcoded in public repo
- Fix Dockerfile AWS CLI install to detect architecture (`amd64`/`arm64`) for multi-platform builds; add `ARG BINARY_URL`; inject AWS credentials via build secret
- Update README: add 26.3.0 as latest tag, update version references from 4.6.1
- Update `docker-compose.yml`: remove secrets section, upgrade postgres 14 → 16

## Build Commands

**QA tag** (`26.3.0-qa`) — private S3, requires AWS credentials:
```bash
docker buildx build --no-cache \
  --platform linux/amd64,linux/arm64 \
  --secret id=aws_credentials,src=$HOME/.aws/credentials \
  --build-arg BINARY_URL="s3://<private-bucket>/bridgelink/26.3.0/binary/BridgeLink_unix_26_3_0.tar.gz" \
  -t innovarhealthcare/bridgelink:26.3.0-qa \
  --push .
```

**Official release** (`26.3.0` + `latest`) — public URL, no AWS credentials needed:
```bash
docker buildx build --no-cache \
  --platform linux/amd64,linux/arm64 \
  --build-arg BINARY_URL="https://innovar-oss-mirth-mirror.s3.us-east-2.amazonaws.com/mirth-arch/BridgeLink-26.3.0/BridgeLink_unix_26_3_0.tar.gz" \
  -t innovarhealthcare/bridgelink:26.3.0 \
  -t innovarhealthcare/bridgelink:latest \
  --push .
```

## Test plan
- [ ] QA build succeeds for `linux/amd64` and `linux/arm64`
- [ ] `26.3.0-qa` image pushed to Docker Hub successfully
- [ ] Container starts and BridgeLink is accessible on port 8443
- [ ] Official release build succeeds without AWS credentials

Resolves: IRT-386

🤖 Generated with [Claude Code](https://claude.com/claude-code)