### PR TITLE
BridgeLink 26.3.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ##### Rockylinux9 OpenJDK 17
 
-* [26.3.0, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_26.3.0/)
+* [26.3.1, latest](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_26.3.1/)
+* [26.3.0](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_26.3.0/)
 * [4.6.1](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.1/Dockerfile)
 * [4.6.0](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.6.0/Dockerfile)
 * [4.5.4](https://github.com/Innovar-Healthcare/bridgelink-container/blob/bl_4.5.4/Dockerfile)
@@ -91,13 +92,13 @@ docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink
 To run a specific version of Connect, specify a tag at the end:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:26.3.0
+docker run --name mybridgelink -d -p 8443:8443 innovarhealthcare/bridgelink:26.3.1
 ```
 
 To run using a specific architecture, specify it using the `--platform` argument:
 
 ```bash
-docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:26.3.0
+docker run --name mybridgelink -d -p 8443:8443 --platform linux/arm64 innovarhealthcare/bridgelink:26.3.1
 ```
 
 Look at the [Environment Variables](#environment-variables) section for more available configuration options.
@@ -119,7 +120,7 @@ Here's an example `stack.yml` file you can use:
 version: "3.1"
 services:
   mc:
-    image: innovarhealthcare/bridgelink:26.3.0
+    image: innovarhealthcare/bridgelink:26.3.1
     platform: linux/amd64
     environment:
         - MP_DATABASE=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bl:
-    image: innovarhealthcare/bridgelink:26.3.0-qa
+    image: innovarhealthcare/bridgelink:26.3.1-qa
     stdin_open: true
     tty: true
     user: 1000:1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bl:
-    image: innovarhealthcare/bridgelink:26.3.1-qa
+    image: innovarhealthcare/bridgelink:26.3.1
     stdin_open: true
     tty: true
     user: 1000:1000
@@ -17,6 +17,8 @@ services:
       MP_KEYSTORE_KEYPASS: bridgelinkKeystore
       MP_KEYSTORE_STOREPASS: bridgelinkKeypass
       MP_CONFIGURATIONMAP_LOCATION: database
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       - postgres
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -130,6 +130,11 @@ for var in $(env | grep '^MP_' | sed 's/=.*//'); do
   # Replace double underscores with dashes and single underscores with dots
   property=$(echo "$var_without_prefix" | tr '[:upper:]' '[:lower:]' | sed 's/__/-/g; s/_/./g')
 
+  # Correct camelCase properties mangled by lowercasing above
+  case "$var_without_prefix" in
+    SERVER_ALLOWROOT) property="server.allowRoot" ;;
+  esac
+
 
   # Choose file to update
   if [ "$var_without_prefix" == "VMOPTIONS" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ fi
 DESTINATION_FOLDER="/opt"
 
 # Name of the downloaded file
-FILE_NAME="BridgeLink_unix_26_3_0.tar.gz"
+FILE_NAME="BridgeLink_unix_26_3_1.tar.gz"
 
 # Log file for debugging
 LOG_FILE="/opt/scripts/download_and_extract.log"


### PR DESCRIPTION
## Summary
- Bump version from 26.3.0 to 26.3.1
- Fix camelCase handling for `server.allowRoot` property in entrypoint.sh
- Add `no-new-privileges` security option to docker-compose
- Update README supported tags and example images to 26.3.1

## Docker Image
- `innovarhealthcare/bridgelink:26.3.1`
- `innovarhealthcare/bridgelink:latest`

## Test plan
- [x] Multi-arch image built (linux/amd64, linux/arm64)
- [x] Image tested locally with docker-compose
- [x] Image pushed to Docker Hub as `:26.3.1` and `:latest`